### PR TITLE
Fix for scrolling issue on ios devices

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -69,7 +69,8 @@ export default class InfiniteScroll extends Component {
   render () {
     const style = {
       height: this.props.height || 'auto',
-      overflow: 'auto'
+      overflow: 'auto',
+      WebkitOverflowScrolling: 'touch'
     };
     const hasChildren = this.props.hasChildren || !!(this.props.children && this.props.children.length);
     return (


### PR DESCRIPTION
Hi,

Scrolling is not smooth on browsers running on ios.

Made "WebkitOverflowScrolling: 'touch'" for smooth scrolling.

https://css-tricks.com/snippets/css/momentum-scrolling-on-ios-overflow-elements/