### PR TITLE
Add prop to receive callback for scroll event

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ name | type | description
 **children** | node (list) | the data items which you need to scroll.
 **loader** | node | you can send a loader component to show while the component waits for the next load of data. e.g. `<h3>Loading...</h3>` or any fancy loader element
 **scrollThreshold** | number | a threshold value after that the InfiniteScroll will call `next`. By default it's `0.8`. It means the `next` will be called when the user comes below 80% of the total height.
-**onScroll** | function | a function that will listen to the scroll event on the scrolling container. Note that the scroll event is debounced, so you may not receive as many events as you would expect. 
+**onScroll** | function | a function that will listen to the scroll event on the scrolling container. Note that the scroll event is throttled, so you may not receive as many events as you would expect. 
 **endMessage** | node |  this message is shown to the user when he has seen all the records which means he's at the bottom and `hasMore` is `false`
 **style** | object | any style which you want to override
 **height** | number | optional, give only if you want to have a fixed height scrolling content

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ name | type | description
 **children** | node (list) | the data items which you need to scroll.
 **loader** | node | you can send a loader component to show while the component waits for the next load of data. e.g. `<h3>Loading...</h3>` or any fancy loader element
 **scrollThreshold** | number | a threshold value after that the InfiniteScroll will call `next`. By default it's `0.8`. It means the `next` will be called when the user comes below 80% of the total height.
+**onScroll** | function | a function that will listen to the scroll event on the scrolling container. Note that the scroll event is debounced, so you may not receive as many events as you would expect. 
 **endMessage** | node |  this message is shown to the user when he has seen all the records which means he's at the bottom and `hasMore` is `false`
 **style** | object | any style which you want to override
 **height** | number | optional, give only if you want to have a fixed height scrolling content

--- a/app/index.js
+++ b/app/index.js
@@ -133,8 +133,11 @@ export default class InfiniteScroll extends Component {
   }
 
   onScrollListener (event) {
-    typeof this.props.onScroll === 'function' &&
-      this.props.onScroll(event);
+    if (this.props.onScroll === 'function') {
+      // Execute this callback in next tick so that it does not affect the
+      // functionality of the library.
+      setTimeout(() => this.props.onScroll(event), 0);
+    }
 
     let target = this.props.height
       ? event.target

--- a/app/index.js
+++ b/app/index.js
@@ -133,7 +133,7 @@ export default class InfiniteScroll extends Component {
   }
 
   onScrollListener (event) {
-    if (this.props.onScroll === 'function') {
+    if (typeof this.props.onScroll === 'function') {
       // Execute this callback in next tick so that it does not affect the
       // functionality of the library.
       setTimeout(() => this.props.onScroll(event), 0);

--- a/app/index.js
+++ b/app/index.js
@@ -133,6 +133,9 @@ export default class InfiniteScroll extends Component {
   }
 
   onScrollListener (event) {
+    typeof this.props.onScroll === 'function' &&
+      this.props.onScroll(event);
+
     let target = this.props.height
       ? event.target
       : (document.documentElement.scrollTop ? document.documentElement : document.body);
@@ -231,4 +234,5 @@ InfiniteScroll.propTypes = {
   releaseToRefreshContent: PropTypes.node,
   pullDownToRefreshThreshold: PropTypes.number,
   refreshFunction: PropTypes.func,
+  onScroll: PropTypes.func,
 };


### PR DESCRIPTION
Fixes #32 

Simply call the provided function from `onScrollListener`. I do not believe the debounce will make any difference to the users.