### PR TITLE
Prop to set initial scroll-y position

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,4 @@ name | type | description
 **releaseToRefreshContent** | node | any JSX that you want to show the user, `default={<h3>Release to refresh</h3>}`
 **pullDownToRefreshThreshold** | number | minimum distance the user needs to pull down to trigger the refresh, `default=100px`
 **refreshFunction** | function | this function will be called, it should return the fresh data that you want to show the user
+**initialScrollY** | number | set a scroll y position for the component to render with.

--- a/app/index.js
+++ b/app/index.js
@@ -30,8 +30,6 @@ export default class InfiniteScroll extends Component {
     this.el = this.props.height ? this._infScroll : window;
     this.el.addEventListener('scroll', this.throttledOnScrollListener);
 
-    console.log(this.el.scrollHeight);
-
     if (
       typeof this.props.initialScrollY === 'number' &&
       this.el.scrollHeight > this.props.initialScrollY

--- a/app/index.js
+++ b/app/index.js
@@ -30,7 +30,12 @@ export default class InfiniteScroll extends Component {
     this.el = this.props.height ? this._infScroll : window;
     this.el.addEventListener('scroll', this.throttledOnScrollListener);
 
-    if (typeof this.props.initialScrollY === 'number') {
+    console.log(this.el.scrollHeight);
+
+    if (
+      typeof this.props.initialScrollY === 'number' &&
+      this.el.scrollHeight > this.props.initialScrollY
+    ) {
       this.el.scrollTo(0, this.props.initialScrollY);
     }
 

--- a/app/index.js
+++ b/app/index.js
@@ -30,6 +30,10 @@ export default class InfiniteScroll extends Component {
     this.el = this.props.height ? this._infScroll : window;
     this.el.addEventListener('scroll', this.throttledOnScrollListener);
 
+    if (typeof this.props.initialScrollY === 'number') {
+      this.el.scrollTo(0, this.props.initialScrollY);
+    }
+
     if (this.props.pullDownToRefresh) {
       document.addEventListener('touchstart', this.onStart);
       document.addEventListener('touchmove', this.onMove);


### PR DESCRIPTION
This is useful if we need to remember the scroll position that the user left in, so that we can re-render in that position.