### PR TITLE
Fix InfiniteScroll to work with zoom levels (browser)

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -136,7 +136,7 @@ export default class InfiniteScroll extends Component {
     ? window.screen.availHeight : target.clientHeight;
 
     const scrolled = scrollThreshold * (target.scrollHeight - target.scrollTop);
-    return scrolled <= clientHeight;
+    return scrolled * window.devicePixelRatio <= clientHeight;
   }
 
   onScrollListener (event) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -118,6 +118,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	      this.el = this.props.height ? this._infScroll : window;
 	      this.el.addEventListener('scroll', this.throttledOnScrollListener);
 
+	      if (typeof this.props.initialScrollY === 'number' && this.el.scrollHeight > this.props.initialScrollY) {
+	        this.el.scrollTo(0, this.props.initialScrollY);
+	      }
+
 	      if (this.props.pullDownToRefresh) {
 	        document.addEventListener('touchstart', this.onStart);
 	        document.addEventListener('touchmove', this.onMove);
@@ -222,11 +226,21 @@ return /******/ (function(modules) { // webpackBootstrap
 	      var clientHeight = target === document.body || target === document.documentElement ? window.screen.availHeight : target.clientHeight;
 
 	      var scrolled = scrollThreshold * (target.scrollHeight - target.scrollTop);
-	      return scrolled <= clientHeight;
+	      return scrolled * window.devicePixelRatio <= clientHeight;
 	    }
 	  }, {
 	    key: 'onScrollListener',
 	    value: function onScrollListener(event) {
+	      var _this2 = this;
+
+	      if (typeof this.props.onScroll === 'function') {
+	        // Execute this callback in next tick so that it does not affect the
+	        // functionality of the library.
+	        setTimeout(function () {
+	          return _this2.props.onScroll(event);
+	        }, 0);
+	      }
+
 	      var target = this.props.height ? event.target : document.documentElement.scrollTop ? document.documentElement : document.body;
 
 	      // if user scrolls up, remove action trigger lock
@@ -254,7 +268,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }, {
 	    key: 'render',
 	    value: function render() {
-	      var _this2 = this;
+	      var _this3 = this;
 
 	      var style = _extends({
 	        height: this.props.height || 'auto',
@@ -274,7 +288,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	          {
 	            className: 'infinite-scroll-component',
 	            ref: function (infScroll) {
-	              return _this2._infScroll = infScroll;
+	              return _this3._infScroll = infScroll;
 	            },
 	            style: style
 	          },
@@ -283,7 +297,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	            {
 	              style: { position: 'relative' },
 	              ref: function (pullDown) {
-	                return _this2._pullDown = pullDown;
+	                return _this3._pullDown = pullDown;
 	              }
 	            },
 	            _react2['default'].createElement(
@@ -341,7 +355,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	  pullDownToRefreshContent: _propTypes2['default'].node,
 	  releaseToRefreshContent: _propTypes2['default'].node,
 	  pullDownToRefreshThreshold: _propTypes2['default'].number,
-	  refreshFunction: _propTypes2['default'].func
+	  refreshFunction: _propTypes2['default'].func,
+	  onScroll: _propTypes2['default'].func
 	};
 	module.exports = exports['default'];
 
@@ -389,11 +404,9 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	/**
 	 * Copyright (c) 2013-present, Facebook, Inc.
-	 * All rights reserved.
 	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
 	 *
 	 * 
 	 */
@@ -430,11 +443,9 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	/**
 	 * Copyright (c) 2013-present, Facebook, Inc.
-	 * All rights reserved.
 	 *
-	 * This source code is licensed under the BSD-style license found in the
-	 * LICENSE file in the root directory of this source tree. An additional grant
-	 * of patent rights can be found in the PATENTS file in the same directory.
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
 	 *
 	 */
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-infinite-scroll-component",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "An Infinite Scroll component in react.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Hi all,

I found an issue related with InfiniteScroll component when the zoom level, in the browser, is different to 100%. You can check on your own Demo page if you select a different zoom level, for example 33%, `isElementAtBottom` always return false.

This change only normalize the target scrolled value with the devicePixelRatio to allow library works with zoom levels (browser).

Thanks!