### PR TITLE
Fix InfiniteScroll to work with zoom levels (browser)

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -136,7 +136,7 @@ export default class InfiniteScroll extends Component {
     ? window.screen.availHeight : target.clientHeight;
 
     const scrolled = scrollThreshold * (target.scrollHeight - target.scrollTop);
-    return scrolled <= clientHeight;
+    return scrolled * (window.devicePixelRatio || 1) <= clientHeight;
   }
 
   onScrollListener (event) {


### PR DESCRIPTION
Hi all,

I found an issue related with InfiniteScroll component when the zoom level, in the browser, is different to 100%. You can check on your own Demo page if you select a different zoom level, for example 33%, isElementAtBottom always return false.

This change only normalize the target scrolled value with the devicePixelRatio to allow library works with zoom levels (browser).

Thanks!