### PR TITLE
Resolve issue with calling 'next' consistently when scroll threshold is passed

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -178,14 +178,10 @@ export default class InfiniteScroll extends Component {
           ? document.documentElement
           : document.body;
 
-    // return immediately if the action has already been triggered,
-    // prevents multiple triggers.
-    if (this.state.actionTriggered) return;
-
     let atBottom = this.isElementAtBottom(target, this.props.scrollThreshold);
 
     // call the `next` function in the props to trigger the next data fetch
-    if (atBottom && this.props.hasMore) {
+    if (atBottom && this.props.hasMore && !this.state.actionTriggered && !this.state.showLoader) {
       this.setState({ actionTriggered: true, showLoader: true });
       this.props.next();
     }

--- a/app/index.js
+++ b/app/index.js
@@ -81,15 +81,14 @@ export default class InfiniteScroll extends Component {
   }
 
   componentWillReceiveProps(props) {
-    // do nothing when dataLength is unchanged
-    if (this.props.dataLength === props.dataLength) return;
-
-    // update state when new data was sent in
-    this.setState({
-      showLoader: false,
-      actionTriggered: false,
-      pullToRefreshThresholdBreached: false
-    });
+     // update state when new data was sent in
+    if (this.props.dataLength !== props.dataLength) {
+      this.setState({
+        showLoader: false,
+        actionTriggered: false,
+        pullToRefreshThresholdBreached: false
+      });
+    }
   }
 
   getScrollableTarget() {
@@ -180,9 +179,11 @@ export default class InfiniteScroll extends Component {
           ? document.documentElement
           : document.body;
 
-    // return immediately if the action has already been triggered,
+    // change actionTriggered and showLoader to false immediately after actionTriggered becoreturn immediately if the action has already been triggered,
     // prevents multiple triggers.
-    if (this.state.actionTriggered) return;
+    if (this.state.actionTriggered) {
+      this.setState({ actionTriggered: false, showLoader: false })
+    }
 
     let atBottom = this.isElementAtBottom(target, this.props.scrollThreshold);
 

--- a/app/index.js
+++ b/app/index.js
@@ -85,7 +85,6 @@ export default class InfiniteScroll extends Component {
     if (this.props.dataLength !== props.dataLength) {
       this.setState({
         showLoader: false,
-        actionTriggered: false,
         pullToRefreshThresholdBreached: false
       });
     }
@@ -190,7 +189,7 @@ export default class InfiniteScroll extends Component {
       this.setState({ actionTriggered: true, showLoader: true });
       this.props.next();
     }
-    this.setState({ lastScrollTop: target.scrollTop });
+    this.setState({ lastScrollTop: target.scrollTop, actionTriggered: false });
   }
 
   render() {

--- a/app/index.js
+++ b/app/index.js
@@ -179,11 +179,9 @@ export default class InfiniteScroll extends Component {
           ? document.documentElement
           : document.body;
 
-    // change actionTriggered and showLoader to false immediately after actionTriggered becoreturn immediately if the action has already been triggered,
+    // return immediately if the action has already been triggered,
     // prevents multiple triggers.
-    if (this.state.actionTriggered) {
-      this.setState({ actionTriggered: false, showLoader: false })
-    }
+    if (this.state.actionTriggered) return;
 
     let atBottom = this.isElementAtBottom(target, this.props.scrollThreshold);
 


### PR DESCRIPTION
While working on my project, I noticed that actionTriggered and showLoader were not changing to false consistently, even though the dataLength has changed. "Next" would only be called once or twice, even though hasMore was set to true and the scroll threshold had been passed. This meant that 'next' was not being called as expected when the scroll threshold was met.

The only consistent way I've found to ensure that "next" is called is to remove the empty return in componentWillReceiveProps and replace it with a declarative if statement and to set "actionTriggered" to false immediately after being called in the onScrollListener function. "showLoader" also now consistently changes to false once new data is loaded.

After identifying a solution, I updated the syntax to remove the empty return and changed componentWillReceiveProps as shown below.

Previous Code:
` componentWillReceiveProps(props) {`
    `  // do nothing when dataLength is unchanged`
   ` if (this.props.dataLength === props.dataLength) return;`
    ` // update state when new data was sent in`
      `this.setState({`
       ` showLoader: false,`
       `actionTriggered: false,`
       ` pullToRefreshThresholdBreached: false`
      `});`
   ` }`
`  }`

Updated Code:
`componentWillReceiveProps(props) {`
    ` // update state when new data was sent in`
   ` if (this.props.dataLength !== props.dataLength) {`
    `  this.setState({`
       ` showLoader: false,`
       ` pullToRefreshThresholdBreached: false`
    `  });`
   ` }`
`  }`

At the bottom of the onScrollListener component I've also added "actionTriggered: false", so that "actionTriggered" is handled immediately after being called. I've also added further conditions to the if statement to ensure that "next" is not called repeatedly and removed the code below, as it was not consistently preventing multiple triggers. 

*...'onScrollListener' function*
Removed Code:
` // return immediately if the action has already been triggered,`
   ` // prevents multiple triggers.`
  `  if (this.state.actionTriggered) return;`

Updated Code:
` // call the `next` function in the props to trigger the next data fetch`
   ` if (atBottom && this.props.hasMore  && !this.state.actionTriggered && !this.state.showLoader) {`
      `this.setState({ actionTriggered: true, showLoader: true });`
    `  this.props.next();`
   ` }`
   ` this.setState({ lastScrollTop: target.scrollTop, actionTriggered: false });`
`  }`