### PR TITLE
Add support to className

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ name | type | description
 **scrollThreshold** | number &#124; string | A threshold value defining when `InfiniteScroll` will call `next`. Default value is `0.8`. It means the `next` will be called when user comes below 80% of the total height. If you pass threshold in pixels (`scrollThreshold="200px"`), `next` will be called once you scroll at least (100% - scrollThreshold) pixels down.  
 **onScroll** | function | a function that will listen to the scroll event on the scrolling container. Note that the scroll event is throttled, so you may not receive as many events as you would expect. 
 **endMessage** | node |  this message is shown to the user when he has seen all the records which means he's at the bottom and `hasMore` is `false`
+**className** | string | add any custom class you want
 **style** | object | any style which you want to override
 **height** | number | optional, give only if you want to have a fixed height scrolling content
 **scrollableTarget** | node or string | optional, reference to a (parent) DOM element that is already providing overflow scrollbars to the `InfiniteScroll` component. *You should provide the `id` of the DOM node preferably.*

--- a/app/index.js
+++ b/app/index.js
@@ -223,7 +223,7 @@ export default class InfiniteScroll extends Component {
     return (
       <div style={outerDivStyle}>
         <div
-          className="infinite-scroll-component"
+          className={`infinite-scroll-component ${this.props.className || ''}`}
           ref={infScroll => (this._infScroll = infScroll)}
           style={style}
         >


### PR DESCRIPTION
Just simple as title says, just add support to `className` in the `<InfiniteScroll .../>` component. 
The lib already has support to style, I think support custom classes could be a simple and nice feature.

Here is the related issue: https://github.com/ankeetmaini/react-infinite-scroll-component/issues/81