### PR TITLE
Add properly support for React >= 16.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/ankeetmaini/react-infinite-scroll-component#readme",
   "peerDependencies": {
-    "react": ">=0.14.0",
+    "react": ">=16.9.0",
     "prop-types": "^15.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/ankeetmaini/react-infinite-scroll-component#readme",
   "peerDependencies": {
-    "react": ">=16.9.0",
+    "react": ">=16.3.0",
     "prop-types": "^15.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Some keys have been moved back to the state because since the `getDerivedStateFromProps` is a static method we can not access, dynamically, the instance values.

Fixes #122 