### PR TITLE
feat: export prop interface

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import { throttle } from 'throttle-debounce';
 import { ThresholdUnits, parseThreshold } from './utils/threshold';
 
 type Fn = () => any;
-interface Props {
+export interface Props {
   next: Fn;
   hasMore: boolean;
   children: ReactNode;


### PR DESCRIPTION
I'd like to access the interface so I can extend it in my custom infinite scroll components.