### PR TITLE
Add infinite scroll on top

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A component to make all your infinite scrolling woes go away with just 4.15 kB! 
 added. An infinite-scroll that actually works and super-simple to integrate!
 
 # install
+
 ```bash
   npm install --save react-infinite-scroll-component
 
@@ -26,7 +27,7 @@ added. An infinite-scroll that actually works and super-simple to integrate!
   hasMore={true}
   loader={<h4>Loading...</h4>}
   endMessage={
-    <p style={{textAlign: 'center'}}>
+    <p style={{ textAlign: 'center' }}>
       <b>Yay! You have seen it all</b>
     </p>
   }
@@ -35,23 +36,55 @@ added. An infinite-scroll that actually works and super-simple to integrate!
   pullDownToRefresh
   pullDownToRefreshThreshold={50}
   pullDownToRefreshContent={
-    <h3 style={{textAlign: 'center'}}>&#8595; Pull down to refresh</h3>
+    <h3 style={{ textAlign: 'center' }}>&#8595; Pull down to refresh</h3>
   }
   releaseToRefreshContent={
-    <h3 style={{textAlign: 'center'}}>&#8593; Release to refresh</h3>
-  }>
+    <h3 style={{ textAlign: 'center' }}>&#8593; Release to refresh</h3>
+  }
+>
   {items}
 </InfiniteScroll>
+```
+
+# using scroll on top
+
+```jsx
+<div
+  id="scrollableDiv"
+  style={{
+    height: 300,
+    overflow: 'auto',
+    display: 'flex',
+    flexDirection: 'column-reverse',
+  }}
+>
+  {/*Put the scroll bar always on the bottom*/}
+  <InfiniteScroll
+    dataLength={this.state.items.length}
+    next={this.fetchMoreData}
+    style={{ display: 'flex', flexDirection: 'column-reverse' }} //To put endMessage and loader to the top.
+    inverse={true} //
+    hasMore={true}
+    loader={<h4>Loading...</h4>}
+    scrollableTarget="scrollableDiv"
+  >
+    {this.state.items.map((_, index) => (
+      <div style={style} key={index}>
+        div - #{index}
+      </div>
+    ))}
+  </InfiniteScroll>
+</div>
 ```
 
 The `InfiniteScroll` component can be used in three ways.
 
 - Specify a value for the `height` prop if you want your **scrollable** content to have a specific height, providing scrollbars for scrolling your content and fetching more data.
 - If your **scrollable** content is being rendered within a parent element that is already providing overflow scrollbars, you can set the `scrollableTarget` prop to reference the DOM element and use it's scrollbars for fetching more data.
-- Without setting either the `height` or `scrollableTarget` props, the scroll will happen at `document.body` like *Facebook's* timeline scroll.
-
+- Without setting either the `height` or `scrollableTarget` props, the scroll will happen at `document.body` like _Facebook's_ timeline scroll.
 
 # docs version wise
+
 [3.0.2](docs/README-3.0.2.md)
 
 # live examples
@@ -66,24 +99,26 @@ The `InfiniteScroll` component can be used in three ways.
   - [![Edit r7rp40n0zm](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/r7rp40n0zm)
 
 # props
-name | type | description
------|------|------------
-**next** | function | a function which must be called after reaching the bottom. It must trigger some sort of action which fetches the next data. **The data is passed as `children` to the `InfiniteScroll` component and the data should contain previous items too.** e.g. *Initial data = [1, 2, 3]* and then next load of data should be *[1, 2, 3, 4, 5, 6]*.
-**hasMore** | boolean | it tells the `InfiniteScroll` component on whether to call `next` function on reaching the bottom and shows an `endMessage` to the user
-**children** | node (list) | the data items which you need to scroll.
-**dataLength** | number | set the length of the data.This will unlock the subsequent calls to next.
-**loader** | node | you can send a loader component to show while the component waits for the next load of data. e.g. `<h3>Loading...</h3>` or any fancy loader element
-**scrollThreshold** | number &#124; string | A threshold value defining when `InfiniteScroll` will call `next`. Default value is `0.8`. It means the `next` will be called when user comes below 80% of the total height. If you pass threshold in pixels (`scrollThreshold="200px"`), `next` will be called once you scroll at least (100% - scrollThreshold) pixels down.  
-**onScroll** | function | a function that will listen to the scroll event on the scrolling container. Note that the scroll event is throttled, so you may not receive as many events as you would expect.
-**endMessage** | node |  this message is shown to the user when he has seen all the records which means he's at the bottom and `hasMore` is `false`
-**className** | string | add any custom class you want
-**style** | object | any style which you want to override
-**height** | number | optional, give only if you want to have a fixed height scrolling content
-**scrollableTarget** | node or string | optional, reference to a (parent) DOM element that is already providing overflow scrollbars to the `InfiniteScroll` component. *You should provide the `id` of the DOM node preferably.*
-**hasChildren** | bool | `children` is by default assumed to be of type array and it's length is used to determine if loader needs to be shown or not, if your `children` is not an array, specify this prop to tell if your items are 0 or more.
-**pullDownToRefresh** | bool | to enable **Pull Down to Refresh** feature
-**pullDownToRefreshContent** | node | any JSX that you want to show the user, `default={<h3>Pull down to refresh</h3>}`
-**releaseToRefreshContent** | node | any JSX that you want to show the user, `default={<h3>Release to refresh</h3>}`
-**pullDownToRefreshThreshold** | number | minimum distance the user needs to pull down to trigger the refresh, `default=100px` , a lower value may be needed to trigger the refresh depending your users browser.
-**refreshFunction** | function | this function will be called, it should return the fresh data that you want to show the user
-**initialScrollY** | number | set a scroll y position for the component to render with.
+
+| name                           | type                 | description                                                                                                                                                                                                                                                                                                                                   |
+| ------------------------------ | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **next**                       | function             | a function which must be called after reaching the bottom. It must trigger some sort of action which fetches the next data. **The data is passed as `children` to the `InfiniteScroll` component and the data should contain previous items too.** e.g. _Initial data = [1, 2, 3]_ and then next load of data should be _[1, 2, 3, 4, 5, 6]_. |
+| **hasMore**                    | boolean              | it tells the `InfiniteScroll` component on whether to call `next` function on reaching the bottom and shows an `endMessage` to the user                                                                                                                                                                                                       |
+| **children**                   | node (list)          | the data items which you need to scroll.                                                                                                                                                                                                                                                                                                      |
+| **dataLength**                 | number               | set the length of the data.This will unlock the subsequent calls to next.                                                                                                                                                                                                                                                                     |
+| **loader**                     | node                 | you can send a loader component to show while the component waits for the next load of data. e.g. `<h3>Loading...</h3>` or any fancy loader element                                                                                                                                                                                           |
+| **scrollThreshold**            | number &#124; string | A threshold value defining when `InfiniteScroll` will call `next`. Default value is `0.8`. It means the `next` will be called when user comes below 80% of the total height. If you pass threshold in pixels (`scrollThreshold="200px"`), `next` will be called once you scroll at least (100% - scrollThreshold) pixels down.                |
+| **onScroll**                   | function             | a function that will listen to the scroll event on the scrolling container. Note that the scroll event is throttled, so you may not receive as many events as you would expect.                                                                                                                                                               |
+| **endMessage**                 | node                 | this message is shown to the user when he has seen all the records which means he's at the bottom and `hasMore` is `false`                                                                                                                                                                                                                    |
+| **className**                  | string               | add any custom class you want                                                                                                                                                                                                                                                                                                                 |
+| **style**                      | object               | any style which you want to override                                                                                                                                                                                                                                                                                                          |
+| **height**                     | number               | optional, give only if you want to have a fixed height scrolling content                                                                                                                                                                                                                                                                      |
+| **scrollableTarget**           | node or string       | optional, reference to a (parent) DOM element that is already providing overflow scrollbars to the `InfiniteScroll` component. _You should provide the `id` of the DOM node preferably._                                                                                                                                                      |
+| **hasChildren**                | bool                 | `children` is by default assumed to be of type array and it's length is used to determine if loader needs to be shown or not, if your `children` is not an array, specify this prop to tell if your items are 0 or more.                                                                                                                      |
+| **pullDownToRefresh**          | bool                 | to enable **Pull Down to Refresh** feature                                                                                                                                                                                                                                                                                                    |
+| **pullDownToRefreshContent**   | node                 | any JSX that you want to show the user, `default={<h3>Pull down to refresh</h3>}`                                                                                                                                                                                                                                                             |
+| **releaseToRefreshContent**    | node                 | any JSX that you want to show the user, `default={<h3>Release to refresh</h3>}`                                                                                                                                                                                                                                                               |
+| **pullDownToRefreshThreshold** | number               | minimum distance the user needs to pull down to trigger the refresh, `default=100px` , a lower value may be needed to trigger the refresh depending your users browser.                                                                                                                                                                       |
+| **refreshFunction**            | function             | this function will be called, it should return the fresh data that you want to show the user                                                                                                                                                                                                                                                  |
+| **initialScrollY**             | number               | set a scroll y position for the component to render with.                                                                                                                                                                                                                                                                                     |
+| **inverse**                    | bool                 | set infinite scroll on top                                                                                                                                                                                                                                                                                                                    |

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ export interface Props {
   height?: number | string;
   scrollableTarget?: ReactNode;
   hasChildren?: boolean;
+  inverse?: boolean;
   pullDownToRefresh?: boolean;
   pullDownToRefreshContent?: ReactNode;
   releaseToRefreshContent?: ReactNode;
@@ -234,6 +235,28 @@ export default class InfiniteScroll extends Component<Props, State> {
     });
   };
 
+  isElementAtTop(target: HTMLElement, scrollThreshold: string | number = 0.8) {
+    const clientHeight =
+      target === document.body || target === document.documentElement
+        ? window.screen.availHeight
+        : target.clientHeight;
+
+    const threshold = parseThreshold(scrollThreshold);
+
+    if (threshold.unit === ThresholdUnits.Pixel) {
+      return (
+        target.scrollTop <
+          threshold.value + clientHeight - target.scrollHeight ||
+        target.scrollTop === 0
+      );
+    }
+    //targe.scrollTop for brave support
+    return (
+      target.scrollTop < threshold.value + clientHeight - target.scrollHeight ||
+      target.scrollTop === 0
+    );
+  }
+
   isElementAtBottom(
     target: HTMLElement,
     scrollThreshold: string | number = 0.8
@@ -275,7 +298,9 @@ export default class InfiniteScroll extends Component<Props, State> {
     // prevents multiple triggers.
     if (this.actionTriggered) return;
 
-    const atBottom = this.isElementAtBottom(target, this.props.scrollThreshold);
+    const atBottom = this.props.inverse
+      ? this.isElementAtTop(target, this.props.scrollThreshold)
+      : this.isElementAtBottom(target, this.props.scrollThreshold);
 
     // call the `next` function in the props to trigger the next data fetch
     if (atBottom && this.props.hasMore) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -245,14 +245,15 @@ export default class InfiniteScroll extends Component<Props, State> {
 
     if (threshold.unit === ThresholdUnits.Pixel) {
       return (
-        target.scrollTop <
-          threshold.value + clientHeight - target.scrollHeight ||
+        target.scrollTop <=
+          threshold.value + clientHeight - target.scrollHeight + 1 ||
         target.scrollTop === 0
       );
     }
-    //targe.scrollTop for brave support
+
     return (
-      target.scrollTop < threshold.value + clientHeight - target.scrollHeight ||
+      target.scrollTop <=
+        threshold.value / 100 + clientHeight - target.scrollHeight + 1 ||
       target.scrollTop === 0
     );
   }

--- a/src/stories/ScrolleableTop.tsx
+++ b/src/stories/ScrolleableTop.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render } from 'react-dom';
+import InfiniteScroll from '../index';
+
+const style = {
+  height: 30,
+  border: '1px solid green',
+  margin: 6,
+  padding: 8,
+};
+
+export default class App extends React.Component {
+  state = {
+    items: Array.from({ length: 20 }),
+  };
+
+  fetchMoreData = () => {
+    // a fake async api call like which sends
+    // 20 more records in 1.5 secs
+    setTimeout(() => {
+      this.setState({
+        items: this.state.items.concat(Array.from({ length: 20 })),
+      });
+    }, 1500);
+  };
+
+  render() {
+    return (
+      <div>
+        <h1>demo: Infinite Scroll on top</h1>
+        <hr />
+        <div
+          id="scrollableDiv"
+          style={{
+            height: 300,
+            overflow: 'auto',
+            display: 'flex',
+            flexDirection: 'column-reverse',
+          }}
+        >
+          <InfiniteScroll
+            dataLength={this.state.items.length}
+            next={this.fetchMoreData}
+            style={{ display: 'flex', flexDirection: 'column-reverse' }} //To put endMessage and loader to the top.
+            inverse={true}
+            hasMore={true}
+            loader={<h4>Loading...</h4>}
+            scrollableTarget="scrollableDiv"
+          >
+            {this.state.items.map((_, index) => (
+              <div style={style} key={index}>
+                div - #{index}
+              </div>
+            ))}
+          </InfiniteScroll>
+        </div>
+      </div>
+    );
+  }
+}
+
+render(<App />, document.getElementById('root'));

--- a/src/stories/stories.tsx
+++ b/src/stories/stories.tsx
@@ -5,6 +5,8 @@ import WindowInf from './WindowInfiniteScrollComponent';
 import PullDownToRefreshInfScroll from './PullDownToRefreshInfScroll';
 import InfiniteScrollWithHeight from './InfiniteScrollWithHeight';
 import ScrollableTargetInfiniteScroll from './ScrollableTargetInfScroll';
+import ScrolleableTop from './ScrolleableTop';
+
 const stories = storiesOf('Components', module);
 
 stories.add('InfiniteScroll', () => <WindowInf />, {
@@ -26,3 +28,7 @@ stories.add(
     info: { inline: true },
   }
 );
+
+stories.add('InfiniteScrollTop', () => <ScrolleableTop />, {
+  info: { inline: true },
+});


### PR DESCRIPTION
**This commit adds the infinite scroll feature on the top of a certain div**
**Example:
![CRM FINANCIALMERC](https://user-images.githubusercontent.com/36203999/92985961-eb5bb780-f47c-11ea-83a4-c7ae123188cf.gif)
**

                <div id="inversecontainer" className="chat-body ps">
                    <div  className="chat" >
                        <InfiniteScroll
                            dataLength={this.state.mensajes.length} //This is important field to render the next data
                            next={() => { this.handleData() }}
                            scrollableTarget={"inversecontainer"} //Scrolleable target 
                            style={{display:"flex",flexDirection:"column-reverse"}} //To put endMessage and loader to the top.
                            inverse={true}
                            loader={<h4>Loading...</h4>}
                            hasMore={this.state.mensajes.length < this.state.count_msn ? true : false}
                            endMessage={
                                <p style={{ textAlign: 'center' }}>
                                    <b>Yay! You have seen it all</b>
                                </p>
                            }>
                            {data} 
                       </InfiniteScroll>
                    </div>
                </div>

Need to add a class on css to put the scrollbar on the bottom always :100: 

```
.ps {
    overflow-y: scroll;
    flex-direction: column-reverse;
}

```