### PR TITLE
Fix will-change value when mouse event ended.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -230,7 +230,7 @@ export default class InfiniteScroll extends Component<Props, State> {
       if (this._infScroll) {
         this._infScroll.style.overflow = 'auto';
         this._infScroll.style.transform = 'none';
-        this._infScroll.style.willChange = 'none';
+        this._infScroll.style.willChange = 'unset';
       }
     });
   };


### PR DESCRIPTION
Follow this document. 
https://developer.mozilla.org/en-US/docs/Web/CSS/will-change

`will-change` doesn't have `none` as value so this one should use `unset` to clear value back to default.

More document for `unset`. https://medium.com/@elad/understanding-the-initial-inherit-and-unset-css-keywords-2d70b7121695