### PR TITLE
fix: scrollTop issue on mobile in inverse mode

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -236,6 +236,9 @@ export default class InfiniteScroll extends Component<Props, State> {
   };
 
   isElementAtTop(target: HTMLElement, scrollThreshold: string | number = 0.8) {
+    const isMobile =
+      navigator.maxTouchPoints || 'ontouchstart' in document.documentElement;
+
     const clientHeight =
       target === document.body || target === document.documentElement
         ? window.screen.availHeight
@@ -243,13 +246,17 @@ export default class InfiniteScroll extends Component<Props, State> {
 
     const threshold = parseThreshold(scrollThreshold);
 
+    if (isMobile && threshold.unit === ThresholdUnits.Pixel)
+      return target.scrollTop <= 200 + threshold.value;
+
+    if (isMobile) return target.scrollTop <= 150;
+
     if (threshold.unit === ThresholdUnits.Pixel) {
       return (
         target.scrollTop <=
         threshold.value + clientHeight - target.scrollHeight + 1
       );
     }
-
     return (
       target.scrollTop <=
       threshold.value / 100 + clientHeight - target.scrollHeight + 1

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -236,8 +236,16 @@ export default class InfiniteScroll extends Component<Props, State> {
   };
 
   isElementAtTop(target: HTMLElement, scrollThreshold: string | number = 0.8) {
+    const getChromeVersion = () => {
+      const raw = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
+
+      return raw ? parseInt(raw[2], 10) : false;
+    };
+
     const isMobile =
       navigator.maxTouchPoints || 'ontouchstart' in document.documentElement;
+
+    const isOldMobileBrowser = isMobile && getChromeVersion() <= 80;
 
     const clientHeight =
       target === document.body || target === document.documentElement
@@ -246,10 +254,10 @@ export default class InfiniteScroll extends Component<Props, State> {
 
     const threshold = parseThreshold(scrollThreshold);
 
-    if (isMobile && threshold.unit === ThresholdUnits.Pixel)
+    if (isOldMobileBrowser && threshold.unit === ThresholdUnits.Pixel)
       return target.scrollTop <= 200 + threshold.value;
 
-    if (isMobile) return target.scrollTop <= 150;
+    if (isOldMobileBrowser) return target.scrollTop <= 150;
 
     if (threshold.unit === ThresholdUnits.Pixel) {
       return (


### PR DESCRIPTION
Fixes #242 

The issue is when we use `flexDirection: 'column-reverse'` . The scroll bar is set to the bottom. On desktop the scrollTop ends with 0 if it reaches the bottom. But it mobile scrollTop behaves oppositely due to `flexDirection: 'column-reverse'`. The scrollTop starts from 0 at the top in mobile.

An example which breaks on mobile: [Link](https://codesandbox.io/s/peaceful-banzai-9sqfd?file=/src/index.js) (check on mobile)

An example which works on mobile [Link](https://codesandbox.io/s/adoring-dhawan-js373?file=/src/index.js) (check on mobile)