### PR TITLE
added passive listener indication to event handlers, to resolve perfo…

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import React, { Component, ReactNode, CSSProperties } from 'react';
 import { throttle } from 'throttle-debounce';
 import { ThresholdUnits, parseThreshold } from './utils/threshold';
+import { supportsPassive } from './utils/passive-event-feature-detection';
 
 type Fn = () => any;
 export interface Props {
@@ -80,9 +81,14 @@ export default class InfiniteScroll extends Component<Props, State> {
       ? this._infScroll
       : this._scrollableNode || window;
 
+    const eventListenerOpts = supportsPassive() ? { passive: true } : false;
+
     if (this.el) {
-      this.el.addEventListener('scroll', this
-        .throttledOnScrollListener as EventListenerOrEventListenerObject);
+      this.el.addEventListener(
+        'scroll',
+        this.throttledOnScrollListener as EventListenerOrEventListenerObject,
+        eventListenerOpts
+      );
     }
 
     if (
@@ -95,13 +101,13 @@ export default class InfiniteScroll extends Component<Props, State> {
     }
 
     if (this.props.pullDownToRefresh && this.el) {
-      this.el.addEventListener('touchstart', this.onStart);
-      this.el.addEventListener('touchmove', this.onMove);
-      this.el.addEventListener('touchend', this.onEnd);
+      this.el.addEventListener('touchstart', this.onStart, eventListenerOpts);
+      this.el.addEventListener('touchmove', this.onMove, eventListenerOpts);
+      this.el.addEventListener('touchend', this.onEnd, eventListenerOpts);
 
-      this.el.addEventListener('mousedown', this.onStart);
-      this.el.addEventListener('mousemove', this.onMove);
-      this.el.addEventListener('mouseup', this.onEnd);
+      this.el.addEventListener('mousedown', this.onStart, eventListenerOpts);
+      this.el.addEventListener('mousemove', this.onMove, eventListenerOpts);
+      this.el.addEventListener('mouseup', this.onEnd, eventListenerOpts);
 
       // get BCR of pullDown element to position it above
       this.maxPullDownDistance =

--- a/src/utils/passive-event-feature-detection.ts
+++ b/src/utils/passive-event-feature-detection.ts
@@ -1,0 +1,26 @@
+/* eslint-disable no-empty */
+
+let cachedResult: null | boolean = null;
+const dummyEventName = 'testPassive' as keyof WindowEventMap;
+
+export function supportsPassive(): boolean {
+  if (cachedResult !== null) {
+    return cachedResult;
+  }
+  if (!window) {
+    return false; // to not fail if used with server-side rendering
+  }
+  try {
+    const opts = Object.defineProperty({}, 'passive', {
+      get: function() {
+        cachedResult = true;
+      },
+    });
+    window.addEventListener(dummyEventName, () => null, opts);
+    window.removeEventListener(dummyEventName, () => null, opts);
+  } catch (e) {}
+  if (cachedResult === null) {
+    cachedResult = false;
+  }
+  return cachedResult;
+}


### PR DESCRIPTION
Added passive event listener indication so browsers supporting this feature will run faster and smoother.
This addresses these types of warnings seen in Dev Tools (Lighthouse):

`[Violation] Added non-passive event listener to a scroll-blocking 'touchstart' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952`

Using this extra parameter requires feature detection. Instead of adding a third-party feature detection library, embedded feature detection code in a new util module.

Based on:

- https://web.dev/uses-passive-event-listeners/
- https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md
