### PR TITLE
Fix: scrollThreshold is not properly applied in inverse mode

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -268,7 +268,7 @@ export default class InfiniteScroll extends Component<Props, State> {
 
     return (
       target.scrollTop <=
-      threshold.value / 100 + clientHeight - target.scrollHeight + 1
+      clientHeight - (threshold.value / 100) * target.scrollHeight + 1
     );
   }
 


### PR DESCRIPTION
### What's happened
In inverse mode, `scrollThreshold` was not properly applied, so we needed to scroll to the end to trigger `next` function calls.

https://user-images.githubusercontent.com/9553914/235976870-9968c5a3-fb5b-4389-a94f-f5262112b47d.mp4

### Solution
We should multiply it with `scrollHeight` as we did in normal mode.

https://user-images.githubusercontent.com/9553914/235977695-6dbf2c8e-d547-4b19-ae20-091f637be5c6.mp4

