### PR TITLE
chore(story): fix window infinite scroll story

### DIFF
--- a/src/stories/WindowInfiniteScrollComponent.tsx
+++ b/src/stories/WindowInfiniteScrollComponent.tsx
@@ -13,7 +13,7 @@ export default class WindowInfiniteScrollComponent extends React.Component<
 
   next = () => {
     setTimeout(() => {
-      const newData = [...this.state.data, new Array(100).fill(1)];
+      const newData = [...this.state.data, ...new Array(100).fill(1)];
       this.setState({ data: newData });
     }, 2000);
   };


### PR DESCRIPTION
Fix to set proper data on refetching new data. The array of 100 elements are pushed as a single element. Spreading it out to push 100 individual elements.