### PR TITLE
Fix target loss in shadow DOM by storing the target element

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -50,6 +50,9 @@ export default class InfiniteScroll extends Component<Props, State> {
     this.onEnd = this.onEnd.bind(this);
   }
 
+  // Fix target loss in shadow DOM by storing the target element
+  private _target: HTMLElement | undefined;
+
   private throttledOnScrollListener: (e: MouseEvent) => void;
   private _scrollableNode: HTMLElement | undefined | null;
   private el: HTMLElement | undefined | Window & typeof globalThis;
@@ -304,14 +307,16 @@ export default class InfiniteScroll extends Component<Props, State> {
 
     const target =
       this.props.height || this._scrollableNode
-        ? (event.target as HTMLElement)
+        ? (event.target as HTMLElement) || this._target
         : document.documentElement.scrollTop
         ? document.documentElement
         : document.body;
 
     // return immediately if the action has already been triggered,
     // prevents multiple triggers.
-    if (this.actionTriggered) return;
+    if (this.actionTriggered || !target) return;
+
+    this._target = target;
 
     const atBottom = this.props.inverse
       ? this.isElementAtTop(target, this.props.scrollThreshold)


### PR DESCRIPTION
This PR addresses part of the concerns raised in #314 .

This pull request includes changes to the `InfiniteScroll` component in `src/index.tsx` to fix an issue with target loss in the shadow DOM. The most important changes include adding a private `_target` property to store the target element and modifying the logic to use this stored target element if necessary.

Improvements to target handling in shadow DOM:

* [`src/index.tsx`](diffhunk://#diff-0b5adbfe7b36e4ae2f479291e20152e33e940f7f265162d77f40f6bdb5da7405R53-R55): Added a private `_target` property to store the target element.
* [`src/index.tsx`](diffhunk://#diff-0b5adbfe7b36e4ae2f479291e20152e33e940f7f265162d77f40f6bdb5da7405L307-R319): Modified the logic to use the stored `_target` element if the event target is not available, and ensured the `_target` is updated with the current target element.