### PR TITLE
fix the problem that the pull down refresh function fails when scrolling to the bottom

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -309,6 +309,10 @@ export default class InfiniteScroll extends Component<Props, State> {
         ? document.documentElement
         : document.body;
 
+    // fix scrollTop is not updated, 
+    // fix: the problem that the pull down refresh function fails when scrolling to the bottom
+    this.lastScrollTop = target.scrollTop;
+    
     // return immediately if the action has already been triggered,
     // prevents multiple triggers.
     if (this.actionTriggered) return;
@@ -324,7 +328,6 @@ export default class InfiniteScroll extends Component<Props, State> {
       this.props.next && this.props.next();
     }
 
-    this.lastScrollTop = target.scrollTop;
   };
 
   render() {


### PR DESCRIPTION
fix the problem that the pull down refresh function fails when scrolling to the bottom.

Because after scrolling to the end, actionTriggered is set to true, when the pull-down refreshes, onStart will be triggered. At this time, lastScrollTop is considered to have a value, so it is returned

![image](https://github.com/user-attachments/assets/dff65e89-a8ae-4f1f-887b-57cef54c80d4)


![image](https://github.com/user-attachments/assets/efb74387-61c7-4d24-a32d-1b2bab2204d0)
