### PR TITLE
fix: corrects the `scrollableTarget` typing to match what is expected

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,7 +12,7 @@ export interface Props {
   endMessage?: ReactNode;
   style?: CSSProperties;
   height?: number | string;
-  scrollableTarget?: ReactNode;
+  scrollableTarget?: HTMLElement | string;
   hasChildren?: boolean;
   inverse?: boolean;
   pullDownToRefresh?: boolean;


### PR DESCRIPTION
I have updated the TypeScript typing for the `scrollableTarget` to match what is expected (`HTMLElement | string`).

Fixes issue: #378 