### PR TITLE
fix: broaden peer dep to support React 18 and 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-infinite-scroll-component",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "An Infinite Scroll component in react.",
   "engines": {
     "node": ">=18.18.0"
@@ -43,8 +43,8 @@
   },
   "homepage": "https://github.com/ankeetmaini/react-infinite-scroll-component#readme",
   "peerDependencies": {
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0"
+    "react": ">=17.0.0",
+    "react-dom": ">=17.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
`^17.0.0` resolves to `>=17 <18`, blocking React 18/19 users at install time with ERESOLVE. The library's class component architecture is identical to v6, which works fine with React 19. Broadening to `>=17.0.0` removes the unnecessary install-time restriction.

Fixes #419