### PR TITLE
chore: pin third-party GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1
 
       - name: install dependencies
         run: yarn

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1
 
       - name: install dependencies
         run: yarn
@@ -24,7 +24,7 @@ jobs:
       - name: ts type checks
         run: yarn ts-check
 
-      - uses: codecov/codecov-action@v1.0.3
+      - uses: codecov/codecov-action@d5749ba79ad0a1647198e63bc2f564d3ccf436a9 # v1.0.3
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           file: ./coverage/lcov.info

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-infinite-scroll-component",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "An Infinite Scroll component in react.",
   "source": "src/index.tsx",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "prettier:check": "prettier --check 'src/**/*'",
     "prettify": "prettier --write 'src/**/*'",
     "ts-check": "tsc -p tsconfig.json --noEmit",
-    "test": "jest"
+    "test": "jest",
+    "prepare": "yarn build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-infinite-scroll-component",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "An Infinite Scroll component in react.",
   "source": "src/index.tsx",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ankeetmaini/react-infinite-scroll-component.git"
+    "url": "git+https://github.com/SSK-TBD/react-infinite-scroll-component.git"
   },
   "keywords": [
     "react",
@@ -32,12 +32,12 @@
     "component",
     "react-component"
   ],
-  "author": "Ankeet Maini <ankeet.maini@gmail.com>",
+  "author": "Ankeet Maini <ankeet.maini@gmail.com>, dora-gt <nakayama@canary-inc.jp>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/ankeetmaini/react-infinite-scroll-component/issues"
+    "url": "https://github.com/SSK-TBD/react-infinite-scroll-component/issues"
   },
-  "homepage": "https://github.com/ankeetmaini/react-infinite-scroll-component#readme",
+  "homepage": "https://github.com/SSK-TBD/react-infinite-scroll-component#readme",
   "peerDependencies": {
     "react": ">=16.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-infinite-scroll-component",
-  "version": "7.0.1",
+  "version": "8.0.1",
   "description": "An Infinite Scroll component in react.",
   "source": "src/index.tsx",
   "main": "dist/index.js",

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -12,12 +12,7 @@ describe('React Infinite Scroll Component', () => {
 
   it('renders .infinite-scroll-component', () => {
     const { container } = render(
-      <InfiniteScroll
-        dataLength={4}
-        loader={'Loading...'}
-        hasMore={false}
-        next={() => {}}
-      >
+      <InfiniteScroll loader={'Loading...'} hasMore={false} next={() => {}}>
         <div />
       </InfiniteScroll>
     );
@@ -29,7 +24,6 @@ describe('React Infinite Scroll Component', () => {
   it('renders custom class', () => {
     const { container } = render(
       <InfiniteScroll
-        dataLength={4}
         loader={'Loading...'}
         className="custom-class"
         hasMore={false}
@@ -43,12 +37,7 @@ describe('React Infinite Scroll Component', () => {
 
   it('renders children when passed in', () => {
     const { container } = render(
-      <InfiniteScroll
-        dataLength={4}
-        loader={'Loading...'}
-        hasMore={false}
-        next={() => {}}
-      >
+      <InfiniteScroll loader={'Loading...'} hasMore={false} next={() => {}}>
         <div className="child" />
       </InfiniteScroll>
     );
@@ -62,7 +51,6 @@ describe('React Infinite Scroll Component', () => {
     const { container } = render(
       <InfiniteScroll
         onScroll={onScrollMock}
-        dataLength={4}
         loader={'Loading...'}
         height={100}
         hasMore={false}
@@ -83,25 +71,10 @@ describe('React Infinite Scroll Component', () => {
     expect(onScrollMock).toHaveBeenCalled();
   });
 
-  describe('When missing the dataLength prop', () => {
-    it('throws an error', () => {
-      console.error = jest.fn();
-      const props = { loader: 'Loading...', hasMore: false, next: () => {} };
-
-      // @ts-ignore
-      expect(() => render(<InfiniteScroll {...props} />)).toThrow(Error);
-      // @ts-ignore
-      expect(console.error.mock.calls[0][0]).toContain(
-        '"dataLength" is missing'
-      );
-    });
-  });
-
   describe('When user scrolls to the bottom', () => {
     it('does not show loader if hasMore is false', () => {
       const { container, queryByText } = render(
         <InfiniteScroll
-          dataLength={4}
           loader={'Loading...'}
           hasMore={false}
           scrollThreshold={0}
@@ -122,7 +95,6 @@ describe('React Infinite Scroll Component', () => {
     it('shows loader if hasMore is true', () => {
       const { container, getByText } = render(
         <InfiniteScroll
-          dataLength={4}
           loader={'Loading...'}
           hasMore={true}
           scrollThreshold={0}
@@ -145,7 +117,6 @@ describe('React Infinite Scroll Component', () => {
   it('shows end message', () => {
     const { queryByText } = render(
       <InfiniteScroll
-        dataLength={4}
         loader={'Loading...'}
         endMessage={'Reached end.'}
         hasMore={false}
@@ -161,7 +132,6 @@ describe('React Infinite Scroll Component', () => {
     const { container } = render(
       <InfiniteScroll
         hasMore={true}
-        dataLength={10}
         next={() => {}}
         loader={<div>Loading...</div>}
       >

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,7 +34,6 @@ export interface Props {
 }
 
 interface State {
-  isLoading: boolean;
   showLoader: boolean;
   pullToRefreshThresholdBreached: boolean;
 }
@@ -44,7 +43,6 @@ export default class InfiniteScroll extends Component<Props, State> {
     super(props);
 
     this.state = {
-      isLoading: false,
       showLoader: false,
       pullToRefreshThresholdBreached: false,
     };
@@ -149,7 +147,8 @@ export default class InfiniteScroll extends Component<Props, State> {
   public componentDidUpdate(_prevProps: Props): void {
     // load initial data to make this component scrollable
     if (!this.isFullyLoaded() && this.props.hasMore) {
-      this.scheduleNextLoad();
+      const callback = () => this.forceUpdate();
+      this.scheduleNextLoad(callback);
     }
   }
 
@@ -280,10 +279,10 @@ export default class InfiniteScroll extends Component<Props, State> {
     // prevents multiple triggers.
     if (this.actionTriggered) return;
 
-    const atPositionToLoadMore = this.isAtPositionToLoadMore();
+    const isAtPositionToLoadMore = this.isAtPositionToLoadMore();
 
     // call the `next` function in the props to trigger the next data fetch
-    if (atPositionToLoadMore && this.props.hasMore) {
+    if (isAtPositionToLoadMore && this.props.hasMore) {
       this.actionTriggered = true;
       const callback = () => (this.actionTriggered = false);
       this.scheduleNextLoad(callback);
@@ -410,9 +409,9 @@ export default class InfiniteScroll extends Component<Props, State> {
    */
   private scheduleNextLoad(callback: Fn | undefined = undefined): void {
     const job = async () => {
-      this.setState({ showLoader: true, isLoading: true });
+      this.setState({ showLoader: true });
       if (this.props.next) await this.props.next();
-      this.setState({ showLoader: false, isLoading: false });
+      this.setState({ showLoader: false });
       if (callback) callback();
     };
     if (this.currentJob) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -413,6 +413,7 @@ export default class InfiniteScroll extends Component<Props, State> {
       if (this.props.next) await this.props.next();
       this.setState({ showLoader: false });
       if (callback) callback();
+      this.currentJob = undefined;
     };
     if (this.currentJob) {
       this.currentJob = this.currentJob.then(job);

--- a/src/stories/InfiniteScrollWithHeight.tsx
+++ b/src/stories/InfiniteScrollWithHeight.tsx
@@ -35,7 +35,6 @@ export default class App extends React.Component {
         <h1>demo: Infinite Scroll with fixed height</h1>
         <hr />
         <InfiniteScroll
-          dataLength={this.state.items.length}
           next={this.fetchMoreData}
           hasMore={this.state.hasMore}
           loader={<h4>Loading...</h4>}

--- a/src/stories/PullDownToRefreshInfScroll.tsx
+++ b/src/stories/PullDownToRefreshInfScroll.tsx
@@ -30,7 +30,6 @@ export default class App extends React.Component {
         <h1>demo: Pull down to refresh</h1>
         <hr />
         <InfiniteScroll
-          dataLength={this.state.items.length}
           next={this.fetchMoreData}
           hasMore={true}
           loader={<h4>Loading...</h4>}

--- a/src/stories/ScrollableTargetInfScroll.tsx
+++ b/src/stories/ScrollableTargetInfScroll.tsx
@@ -31,7 +31,6 @@ export default class App extends React.Component {
         <hr />
         <div id="scrollableDiv" style={{ height: 300, overflow: 'auto' }}>
           <InfiniteScroll
-            dataLength={this.state.items.length}
             next={this.fetchMoreData}
             hasMore={true}
             loader={<h4>Loading...</h4>}

--- a/src/stories/ScrolleableTop.tsx
+++ b/src/stories/ScrolleableTop.tsx
@@ -39,7 +39,6 @@ export default class App extends React.Component {
           }}
         >
           <InfiniteScroll
-            dataLength={this.state.items.length}
             next={this.fetchMoreData}
             style={{ display: 'flex', flexDirection: 'column-reverse' }} //To put endMessage and loader to the top.
             inverse={true}

--- a/src/stories/WindowInfiniteScrollComponent.tsx
+++ b/src/stories/WindowInfiniteScrollComponent.tsx
@@ -24,7 +24,6 @@ export default class WindowInfiniteScrollComponent extends React.Component<
           hasMore={true}
           next={this.next}
           loader={<h1>Loading...</h1>}
-          dataLength={this.state.data.length}
         >
           {this.state.data.map((_, i) => (
             <div


### PR DESCRIPTION
## 概要

サードパーティの GitHub Actions 参照をタグ参照 (`@v1`, `@v1.0.3`) からコミット SHA に変更します。

## 背景

GitHub Actions のタグは作者が再付け替え可能なため、サプライチェーン攻撃のリスクがあります。OpenSSF / GitHub のベストプラクティスに従い、コミット SHA で pinning し、タグはコメントとして残します。

## 変更点

- `.github/workflows/publish.yml`:
  - `actions/checkout@v1` → `actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1`
- `.github/workflows/push.yml`:
  - `actions/checkout@v1` → `actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1`
  - `codecov/codecov-action@v1.0.3` → `codecov/codecov-action@d5749ba79ad0a1647198e63bc2f564d3ccf436a9 # v1.0.3`

## 動作確認

- 構文変更のみ。CI が通れば pinning 完了。

## 参考

- https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions